### PR TITLE
fix: `maybe uninitialized` warning on `voltage` in `convertToVoltage`

### DIFF
--- a/src/ADS1115.cpp
+++ b/src/ADS1115.cpp
@@ -248,7 +248,7 @@ Status ADS1115_ADC::readConversionVoltage(float& voltage) {
 }
 
 float ADS1115_ADC::convertToVoltage(const int16_t value) {
-  float voltage;
+  float voltage = 0.0f;
 
   switch (_pga) {
     case Pga::FSR_0_256V: voltage = value * _fsr_0_256; break;


### PR DESCRIPTION
Raised on some compilers. Set the initial value for local variable.